### PR TITLE
Add non-Varia heat damage setting to slot data

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -157,6 +157,7 @@ class MetroidPrimeWorld(World):
             "required_artifacts": self.options.required_artifacts.value,
             "missile_launcher": self.options.missile_launcher.value,
             "main_power_bomb": self.options.main_power_bomb.value,
+            "non_varia_heat_damage": self.options.non_varia_heat_damage.value,
             "exclude_items": self.options.exclude_items.value,
             "final_bosses": self.options.final_bosses.value,
         }


### PR DESCRIPTION
This is adding the non-Varia heat damage setting to the slot data since it was missing.  I was looking at making a PopTracker pack for this with autotracking support and this is needed for logic.