### PR TITLE
Small Changes

### DIFF
--- a/LogicCombat.py
+++ b/LogicCombat.py
@@ -36,8 +36,8 @@ def can_combat_mines(state: CollectionState, player: int) -> bool:
 
 
 def can_combat_labs(state: CollectionState, player: int) -> bool:
-    return _get_options(state, player).starting_room_name.value in [RoomName.East_Tower.value, RoomName.Save_Station_B.value]
-           or _can_combat_generic(state, player, 1, 0, False)
+    return (_get_options(state, player).starting_room_name.value in [RoomName.East_Tower.value, RoomName.Save_Station_B.value]
+           or _can_combat_generic(state, player, 1, 0, False))
 
 
 def can_combat_thardus(state: CollectionState, player: int) -> bool:
@@ -58,8 +58,8 @@ def can_combat_omega_pirate(state: CollectionState, player: int) -> bool:
 
 
 def can_combat_flaaghra(state: CollectionState, player: int) -> bool:
-    return _get_options(state, player).starting_room_name == RoomName.Sunchamber_Lobby.value
-           or _can_combat_generic(state, player, 2, 1, False)
+    return (_get_options(state, player).starting_room_name == RoomName.Sunchamber_Lobby.value
+           or _can_combat_generic(state, player, 2, 1, False))
 
 
 def can_combat_ridley(state: CollectionState, player: int) -> bool:

--- a/LogicCombat.py
+++ b/LogicCombat.py
@@ -26,9 +26,9 @@ def _can_combat_generic(state: CollectionState, player: int, normal_tanks: int, 
     if difficulty == CombatLogicDifficulty.NO_LOGIC.value:
         return True
     elif difficulty == CombatLogicDifficulty.NORMAL.value:
-        return has_energy_tanks(state, player, normal_tanks) and (can_charge_beam(state, player) if requires_charge_beam else True)
+        return has_energy_tanks(state, player, normal_tanks) and (can_charge_beam(state, player) or not requires_charge_beam)
     elif difficulty == CombatLogicDifficulty.MINIMAL.value:
-        return has_energy_tanks(state, player, minimal_tanks) and (can_charge_beam(state, player) if requires_charge_beam else True)
+        return has_energy_tanks(state, player, minimal_tanks) and (can_charge_beam(state, player) or not requires_charge_beam)
 
 
 def can_combat_mines(state: CollectionState, player: int) -> bool:
@@ -36,9 +36,8 @@ def can_combat_mines(state: CollectionState, player: int) -> bool:
 
 
 def can_combat_labs(state: CollectionState, player: int) -> bool:
-    if _get_options(state, player).starting_room_name.value in [RoomName.East_Tower.value, RoomName.Save_Station_B.value]:
-        return True
-    return _can_combat_generic(state, player, 1, 0, False)
+    return _get_options(state, player).starting_room_name.value in [RoomName.East_Tower.value, RoomName.Save_Station_B.value]
+           or _can_combat_generic(state, player, 1, 0, False)
 
 
 def can_combat_thardus(state: CollectionState, player: int) -> bool:
@@ -59,9 +58,8 @@ def can_combat_omega_pirate(state: CollectionState, player: int) -> bool:
 
 
 def can_combat_flaaghra(state: CollectionState, player: int) -> bool:
-    if _get_options(state, player).starting_room_name == RoomName.Sunchamber_Lobby.value:
-        return True
-    return _can_combat_generic(state, player, 2, 1, requires_charge_beam=False)
+    return _get_options(state, player).starting_room_name == RoomName.Sunchamber_Lobby.value
+           or _can_combat_generic(state, player, 2, 1, False)
 
 
 def can_combat_ridley(state: CollectionState, player: int) -> bool:

--- a/Regions.py
+++ b/Regions.py
@@ -57,6 +57,8 @@ def create_regions(world: 'MetroidPrimeWorld', final_boss_selection):
             can_phazon(state, world.player) and
             can_plasma_beam(state, world.player) and can_wave_beam(state, world.player) and can_ice_beam(state, world.player) and can_power_beam(state, world.player) and
             can_xray(state, world.player, True) and can_thermal(state, world.player, True)))
+        impact_crater.connect(mission_complete, "Mission Complete")
+
     elif final_boss_selection == 1:
         artifact_temple.connect(mission_complete, "Mission Complete", lambda state:
                                 can_missile(state, world.player) and
@@ -67,10 +69,6 @@ def create_regions(world: 'MetroidPrimeWorld', final_boss_selection):
         artifact_temple.connect(mission_complete, "Mission Complete", lambda state: (
             can_missile(state, world.player) and
             has_required_artifact_count(state, world.player)))
-
-    if (final_boss_selection == 0 or
-            final_boss_selection == 2):
-        impact_crater.connect(mission_complete, "Mission Complete")
 
     # from Utils import visualize_regions
     # visualize_regions(world.multiworld.get_region("Menu", world.player), "my_world.puml")


### PR DESCRIPTION
Some small changes to speed up / cleanup some True/False returns.
Moving Mission Complete connection because the logic was identical (`if final_boss_selection == 0 or final_boss_selection == 2`).
Using `world.player_name` instead of `world.multiworld.get_player_name(self.player)`.
Removing `.keys()` when iterating over a dictionary because they are the same.
Added a `local_itempool` so the multiworld itempool can be accessed exactly once.
Changed an `if/elif` chains because they used `continue` and just `if` was equivalent.
Moved `post_fill` to when/where it would actually be called so it makes more sense visually.

Did several test generations and compared the spoiler logs and output before and after the changes on the same seeds.