### PR TITLE
Update Thermal/XRay Requirements to allow for less strict logic

### DIFF
--- a/Logic.py
+++ b/Logic.py
@@ -82,7 +82,7 @@ def can_morph_ball(state: CollectionState, player: int) -> bool:
 def can_xray(state: CollectionState, player: int, usually_required: bool = False, hard_required: bool = False) -> bool:
     if hard_required:
         return state.has(SuitUpgrade.X_Ray_Visor.value, player)
-    if usually_required and _get_options(state, player).remove_xray_requirements == "remove_prime":
+    if usually_required and _get_options(state, player).remove_xray_requirements == "remove_all_but_omega_pirate":
         return True
     if usually_required:
         return state.has(SuitUpgrade.X_Ray_Visor.value, player)

--- a/Logic.py
+++ b/Logic.py
@@ -79,18 +79,18 @@ def can_morph_ball(state: CollectionState, player: int) -> bool:
     return state.has(SuitUpgrade.Morph_Ball.value, player)
 
 
-def can_xray(state: CollectionState, player: int, hard_required: bool = False) -> bool:
+def can_xray(state: CollectionState, player: int, usually_required: bool = False, hard_required: bool = False) -> bool:
     if hard_required:
         return state.has(SuitUpgrade.X_Ray_Visor.value, player)
-    elif _get_options(state, player).remove_xray_requirements.value:
+    if usually_required and _get_options(state, player).remove_xray_requirements.value:
         return True
     return state.has(SuitUpgrade.X_Ray_Visor.value, player)
 
 
-def can_thermal(state: CollectionState, player: int, hard_required: bool = False) -> bool:
+def can_thermal(state: CollectionState, player: int, usually_required: bool = False, hard_required: bool = False) -> bool:
     if hard_required:
         return state.has(SuitUpgrade.Thermal_Visor.value, player)
-    elif _get_options(state, player).remove_thermal_requirements.value:
+    if usually_required and _get_options(state, player).remove_thermal_requirements.value:
         return True
     return state.has(SuitUpgrade.Thermal_Visor.value, player)
 

--- a/Logic.py
+++ b/Logic.py
@@ -84,7 +84,9 @@ def can_xray(state: CollectionState, player: int, usually_required: bool = False
         return state.has(SuitUpgrade.X_Ray_Visor.value, player)
     if usually_required and _get_options(state, player).remove_xray_requirements == "remove_prime":
         return True
-    return state.has(SuitUpgrade.X_Ray_Visor.value, player)
+    if usually_required:
+        return state.has(SuitUpgrade.X_Ray_Visor.value, player)
+    return _get_options(state, player).remove_xray_requirements.value or state.has(SuitUpgrade.X_Ray_Visor.value, player)
 
 
 def can_thermal(state: CollectionState, player: int, usually_required: bool = False, hard_required: bool = False) -> bool:
@@ -92,7 +94,9 @@ def can_thermal(state: CollectionState, player: int, usually_required: bool = Fa
         return state.has(SuitUpgrade.Thermal_Visor.value, player)
     if usually_required and _get_options(state, player).remove_thermal_requirements == "remove_all":
         return True
-    return state.has(SuitUpgrade.Thermal_Visor.value, player)
+    if usually_required:
+        return state.has(SuitUpgrade.Thermal_Visor.value, player)
+    return _get_options(state, player).remove_thermal_requirements.value or state.has(SuitUpgrade.Thermal_Visor.value, player)
 
 
 def can_move_underwater(state: CollectionState, player: int) -> bool:

--- a/Logic.py
+++ b/Logic.py
@@ -82,7 +82,7 @@ def can_morph_ball(state: CollectionState, player: int) -> bool:
 def can_xray(state: CollectionState, player: int, usually_required: bool = False, hard_required: bool = False) -> bool:
     if hard_required:
         return state.has(SuitUpgrade.X_Ray_Visor.value, player)
-    if usually_required and _get_options(state, player).remove_xray_requirements.value:
+    if usually_required and _get_options(state, player).remove_xray_requirements == "remove_prime":
         return True
     return state.has(SuitUpgrade.X_Ray_Visor.value, player)
 
@@ -90,7 +90,7 @@ def can_xray(state: CollectionState, player: int, usually_required: bool = False
 def can_thermal(state: CollectionState, player: int, usually_required: bool = False, hard_required: bool = False) -> bool:
     if hard_required:
         return state.has(SuitUpgrade.Thermal_Visor.value, player)
-    if usually_required and _get_options(state, player).remove_thermal_requirements.value:
+    if usually_required and _get_options(state, player).remove_thermal_requirements == "remove_all":
         return True
     return state.has(SuitUpgrade.Thermal_Visor.value, player)
 

--- a/PrimeOptions.py
+++ b/PrimeOptions.py
@@ -145,8 +145,8 @@ class FlaahgraPowerBombs(Toggle):
 class RemoveXrayRequirements(Choice):
     """Determines the xray visor requirements
        remove_none: No xray visor requirements are removed.
-       remove_most: All xray visor requirements are removed except for metroid prime and chozo ghosts.
-       remove_prime: All xray visor requirements are removed except for metroid prime
+       remove_most: All xray visor requirements are removed except for metroid prime, chozo ghosts (normal/minimal combat difficulty), and omega pirate.
+       remove_all_but_omega: All xray visor requirements are removed except for omega pirate.
     """
     display_name = "Remove Xray Visor Requirements"
     option_remove_none = 0
@@ -161,12 +161,12 @@ class RemoveThermalRequirements(Choice):
     """Determines the thermal visor requirements
        remove_none: No thermal visor requirements are removed.
        remove_most: All thermal visor requirements are removed except for metroid prime (note this means wave beam panels will be in logic without the visor to see them).
-       remove_prime: All thermal visor requirements are removed (note this means wave beam panels will be in logic without the visor to see them). 
+       remove_all: All thermal visor requirements are removed (note this means wave beam panels will be in logic without the visor to see them).
     """
     display_name = "Remove Thermal Visor Requirements"
     option_remove_none = 0
     alias_false = 0
-    options_most = 1
+    option_remove_most = 1
     alias_true = 1
     option_remove_all = 2
     default = 0

--- a/PrimeOptions.py
+++ b/PrimeOptions.py
@@ -142,16 +142,34 @@ class FlaahgraPowerBombs(Toggle):
     default = False
 
 
-class RemoveXrayRequirements(Toggle):
-    """If enabled, removes xray visor requirements for everything but omega pirate and metroid prime"""
+class RemoveXrayRequirements(Choice):
+    """Determines the xray visor requirements
+       remove_none: No xray visor requirements are removed.
+       remove_most: All xray visor requirements are removed except for metroid prime and chozo ghosts.
+       remove_prime: All xray visor requirements are removed except for metroid prime
+    """
     display_name = "Remove Xray Visor Requirements"
-    default = False
+    option_remove_none = 0
+    alias_false = 0
+    option_remove_most = 1
+    alias_true = 1
+    option_remove_prime = 2
+    default = 0
 
 
-class RemoveThermalRequirements(Toggle):
-    """If enabled, removes thermal visor requirements for everything but metroid prime (note this means wave beam panels will be in logic without the visor to see them)"""
+class RemoveThermalRequirements(Choice):
+    """Determines the thermal visor requirements
+       remove_none: No thermal visor requirements are removed.
+       remove_most: All thermal visor requirements are removed except for metroid prime (note this means wave beam panels will be in logic without the visor to see them).
+       remove_prime: All thermal visor requirements are removed (note this means wave beam panels will be in logic without the visor to see them). 
+    """
     display_name = "Remove Thermal Visor Requirements"
-    default = False
+    option_remove_none = 0
+    alias_false = 0
+    options_most = 1
+    alias_true = 1
+    option_remove_all = 2
+    default = 0
 
 
 class StartingRoom(Choice):

--- a/PrimeOptions.py
+++ b/PrimeOptions.py
@@ -146,14 +146,14 @@ class RemoveXrayRequirements(Choice):
     """Determines the xray visor requirements
        remove_none: No xray visor requirements are removed.
        remove_most: All xray visor requirements are removed except for metroid prime, chozo ghosts (normal/minimal combat difficulty), and omega pirate.
-       remove_all_but_omega: All xray visor requirements are removed except for omega pirate.
+       remove_all_but_omega_pirate: All xray visor requirements are removed except for omega pirate.
     """
     display_name = "Remove Xray Visor Requirements"
     option_remove_none = 0
     alias_false = 0
     option_remove_most = 1
     alias_true = 1
-    option_remove_prime = 2
+    option_remove_all_but_omega_pirate = 2
     default = 0
 
 

--- a/Regions.py
+++ b/Regions.py
@@ -48,7 +48,7 @@ def create_regions(world: 'MetroidPrimeWorld', final_boss_selection):
             can_combat_ridley(state, world.player) and
             can_phazon(state, world.player) and
             can_plasma_beam(state, world.player) and can_wave_beam(state, world.player) and can_ice_beam(state, world.player) and can_power_beam(state, world.player) and
-            can_xray(state, world.player, hard_required=True) and can_thermal(state, world.player, hard_required=True)))
+            can_xray(state, world.player, True) and can_thermal(state, world.player, True)))
         impact_crater.connect(mission_complete, "Mission Complete")
 
     elif final_boss_selection == 1:

--- a/Regions.py
+++ b/Regions.py
@@ -48,7 +48,7 @@ def create_regions(world: 'MetroidPrimeWorld', final_boss_selection):
             can_combat_ridley(state, world.player) and
             can_phazon(state, world.player) and
             can_plasma_beam(state, world.player) and can_wave_beam(state, world.player) and can_ice_beam(state, world.player) and can_power_beam(state, world.player) and
-            can_xray(state, world.player, True) and can_thermal(state, world.player, True)))
+            can_xray(state, world.player, hard_required=True) and can_thermal(state, world.player, hard_required=True)))
         impact_crater.connect(mission_complete, "Mission Complete")
 
     elif final_boss_selection == 1:

--- a/data/PhazonMines.py
+++ b/data/PhazonMines.py
@@ -56,10 +56,10 @@ class PhazonMinesAreaData(AreaData):
             }),
             RoomName.Elite_Quarters: RoomData(
                 doors={
-                    0: DoorData(RoomName.Elite_Quarters_Access, defaultLock=DoorLockType.Plasma, rule_func=lambda state, player: can_combat_omega_pirate(state, player) and can_xray(state, player, True)),
-                    1: DoorData(RoomName.Processing_Center_Access, defaultLock=DoorLockType.Plasma, rule_func=lambda state, player: can_combat_omega_pirate(state, player) and can_xray(state, player, True) and can_scan(state, player)),
+                    0: DoorData(RoomName.Elite_Quarters_Access, defaultLock=DoorLockType.Plasma, rule_func=lambda state, player: can_combat_omega_pirate(state, player) and can_xray(state, player, hard_required=True)),
+                    1: DoorData(RoomName.Processing_Center_Access, defaultLock=DoorLockType.Plasma, rule_func=lambda state, player: can_combat_omega_pirate(state, player) and can_xray(state, player, hard_required=True) and can_scan(state, player)),
                 },
-                pickups=[PickupData('Phazon Mines: Elite Quarters', rule_func=lambda state, player: can_combat_omega_pirate(state, player) and can_xray(state, player, True)), ]),
+                pickups=[PickupData('Phazon Mines: Elite Quarters', rule_func=lambda state, player: can_combat_omega_pirate(state, player) and can_xray(state, player, hard_required=True)), ]),
             RoomName.Elite_Research: RoomData(
                 doors={
                     0: DoorData(RoomName.Research_Access, defaultLock=DoorLockType.Ice, rule_func=lambda state, player: can_bomb(state, player) and can_boost(state, player) and can_space_jump(state, player) and can_scan(state, player), tricks=[Tricks.elite_research_spinner_no_boost]),


### PR DESCRIPTION
Changes the XRay and Thermal requirement options into Choice options so that players can remove the Prime and Chozo Ghosts logic considerations as well.

The option aliases are so that these will still work with old yamls from when these were toggles.

This was tested by plando'ing an artifact onto "Phazon Mines: Elite Quarters" (hard requires xray), "Phazon Mines: Metroid Quarantine A" (soft requires xray), or ""Phazon Mines: Main Quarry" (soft requires thermal) while removing the visors from the itempool and seeing that generations only failed when expected. The final bosses option was used to check values worked properly and lead to unwinnable worlds as well.