### PR TITLE
Add crashed frigate front access rule

### DIFF
--- a/data/TallonOverworld.py
+++ b/data/TallonOverworld.py
@@ -30,13 +30,21 @@ if TYPE_CHECKING:
     from .. import MetroidPrimeWorld
 
 
+def can_crashed_frigate_front(world: "MetroidPrimeWorld", state: CollectionState) -> bool:
+    return (
+        can_morph_ball(world, state)
+        and can_wave_beam(world, state)
+        and can_thermal(world, state)
+        and (can_move_underwater(world, state) or can_space_jump(world, state))
+    )
+
+
 def can_crashed_frigate(world: "MetroidPrimeWorld", state: CollectionState) -> bool:
     return (
-        can_bomb(world, state)
+        can_crashed_frigate_front(world, state)
+        and can_bomb(world, state)
         and can_space_jump(world, state)
-        and can_wave_beam(world, state)
         and can_move_underwater(world, state)
-        and can_thermal(world, state)
     )
 
 
@@ -135,7 +143,7 @@ class TallonOverworldAreaData(AreaData):
                             can_missile(world, state) or can_charge_beam(world, state)
                         )
                         and (
-                            can_crashed_frigate(world, state)
+                            can_crashed_frigate_front(world, state)
                             or can_crashed_frigate_backwards(world, state)
                         ),
                     ),
@@ -153,7 +161,7 @@ class TallonOverworldAreaData(AreaData):
                 doors={
                     0: DoorData(
                         RoomName.Cargo_Freight_Lift_to_Deck_Gamma,
-                        rule_func=can_crashed_frigate,
+                        rule_func=can_crashed_frigate_front,
                         tricks=[Tricks.frigate_no_gravity],
                         exclude_from_rando=True,
                     ),


### PR DESCRIPTION
The access rules for the crashed frigate expect Bombs and Gravity Suit to access Cargo Freight Lift to Deck Gamma, which is unnecessarily restrictive. This adds a new rule to the front of the frigate so that the E-tank is in logic without either.