### PR TITLE
Add support for Nintendont

### DIFF
--- a/ClientReceiveItems.py
+++ b/ClientReceiveItems.py
@@ -148,16 +148,15 @@ async def handle_receive_missiles(
         diff = new_capacity - current_capacity
         new_amount = min(current_amount + diff, new_capacity)
 
-        await ctx.game_interface.give_item_to_player(
-            missile_item.id, new_amount, new_capacity
-        )
-        if missile_sender != ctx.slot and diff > 0 and missile_sender != None:
-            message = (
-                f"Missile capacity increased by {diff}"
-                if diff > 5
-                else f"Missile capacity increased by {diff} ({ctx.player_names[missile_sender]})"
-            )
-            ctx.notification_manager.queue_notification(message)
+        if diff > 0:
+            await ctx.game_interface.give_item_to_player(missile_item.id, new_amount, new_capacity)
+            if missile_sender not in (ctx.slot, None):
+                message = (
+                    f"Missile capacity increased by {diff}"
+                    if diff > 5
+                    else f"Missile capacity increased by {diff} ({ctx.player_names[missile_sender]})"
+                )
+                ctx.notification_manager.queue_notification(message)
 
 
 async def handle_receive_power_bombs(
@@ -207,14 +206,15 @@ async def handle_receive_power_bombs(
         diff = new_capacity - current_capacity
         new_amount = min(current_amount + diff, new_capacity)
 
-        await ctx.game_interface.give_item_to_player(pb_item.id, new_amount, new_capacity)
-        if pb_sender != ctx.slot and diff > 0 and pb_sender != None:
-            message = (
-                f"Power Bomb capacity increased by {diff}"
-                if diff > 5
-                else f"Power Bomb capacity increased by {diff} ({ctx.player_names[pb_sender]})"
-            )
-            ctx.notification_manager.queue_notification(message)
+        if diff > 0:
+            await ctx.game_interface.give_item_to_player(pb_item.id, new_amount, new_capacity)
+            if pb_sender not in (ctx.slot, None):
+                message = (
+                    f"Power Bomb capacity increased by {diff}"
+                    if diff > 5
+                    else f"Power Bomb capacity increased by {diff} ({ctx.player_names[pb_sender]})"
+                )
+                ctx.notification_manager.queue_notification(message)
 
 
 async def handle_receive_energy_tanks(
@@ -235,14 +235,9 @@ async def handle_receive_energy_tanks(
                 energy_tank_sender = network_item.player
 
         diff = num_energy_tanks_received - energy_tank_item.current_capacity
-        if (
-            diff > 0
-            and energy_tank_item.current_capacity < energy_tank_item.max_capacity
-        ):
+        if diff > 0 and energy_tank_item.current_capacity < energy_tank_item.max_capacity:
             new_capacity = min(num_energy_tanks_received, energy_tank_item.max_capacity)
-            await ctx.game_interface.give_item_to_player(
-                energy_tank_item.id, new_capacity, new_capacity
-            )
+            await ctx.game_interface.give_item_to_player(energy_tank_item.id, new_capacity, new_capacity)
 
             if energy_tank_sender != ctx.slot and diff > 0:
                 message = (

--- a/ClientReceiveItems.py
+++ b/ClientReceiveItems.py
@@ -17,6 +17,12 @@ if TYPE_CHECKING:
 async def handle_receive_items(
     ctx: "MetroidPrimeContext", current_items: Dict[str, InventoryItemData]
 ):
+    # If the server state resets or something, ctx.items_received can get cleared.
+    # Since we depend on len(ctx.items_received) - 1 and the power suit is always in the start inventory,
+    # we can just wait for it to get filled again.
+    if not ctx.items_received:
+        return
+
     # Will be used when consumables are implemented
     # current_index = await ctx.game_interface.get_last_received_index()
     for network_item in ctx.items_received:

--- a/GameCubeClient.py
+++ b/GameCubeClient.py
@@ -1,7 +1,11 @@
 from abc import ABC, abstractmethod
+from enum import IntEnum, IntFlag
+import itertools
 from logging import Logger
-from typing import Any
+import struct
+from typing import Any, NamedTuple, cast
 import dolphin_memory_engine  # type: ignore
+import socket
 import subprocess
 import Utils
 
@@ -13,6 +17,10 @@ class GameCubeException(Exception):
 
 
 class DolphinException(GameCubeException):
+    pass
+
+
+class NintendontException(GameCubeException):
     pass
 
 
@@ -150,3 +158,180 @@ def get_num_dolphin_instances() -> int:
         return 0
     except:
         return 0
+
+
+NINTENDONT_PORT = 43673
+
+
+class NintendontMemoryOperationType(IntEnum):
+    READ_COMMANDS = 0
+    REQUEST_VERSION = 1
+
+
+class NintendontOperationHeader(IntFlag):
+    HAS_READ = 0x80
+    HAS_WRITE = 0x40
+    IS_WORD = 0x20
+    HAS_OFFSET = 0x10
+    ADDRESS_INDEX_MASK = 0xF
+
+    @classmethod
+    def make(cls, read: bool, write: bool, is_word: bool, indirect: bool, address_index: int):
+        if address_index > cls.ADDRESS_INDEX_MASK:
+            raise ValueError(f"Address index too large: Max {cls.ADDRESS_INDEX_MASK}, got {address_index}")
+        if address_index < 0:
+            raise ValueError(f"Address must be nonnegative, got {address_index}")
+        self = cls(address_index)
+        if read:
+            self |= cls.HAS_READ
+        if write:
+            self |= cls.HAS_WRITE
+        if is_word:
+            self |= cls.IS_WORD
+        if indirect:
+            self |= cls.HAS_OFFSET
+        return self
+
+
+# No support for words
+class NintendontOperation(NamedTuple):
+    header: NintendontOperationHeader
+    size: int
+    indirect_offset: int | None
+    data: bytes | None
+
+    @classmethod
+    def make_read(cls, address_index: int, size: int, indirect_offset: int | None = None):
+        header = NintendontOperationHeader.make(True, False, False, indirect_offset is not None, address_index)
+        return cls(header, size, indirect_offset, None)
+
+    @classmethod
+    def make_write(cls, read: int, address_index: int, data: bytes, indirect_offset: int | None = None):
+        header = NintendontOperationHeader.make(read, True, False, indirect_offset is not None, address_index)
+        return cls(header, len(data), indirect_offset, data)
+
+    def is_read(self) -> bool:
+        return NintendontOperationHeader.HAS_READ in self.header
+
+    def to_bytes(self) -> bytes:
+        if self.indirect_offset is None:
+            data = struct.pack(">BB", self.header, self.size)
+        else:
+            data = struct.pack(">BBH", self.header, self.size, self.indirect_offset)
+        if self.data is None:
+            return data
+        else:
+            return data + self.data
+
+class NintendontMetaInfo(NamedTuple):
+    protocol_version: int
+    max_input_bytes: int
+    max_output_bytes: int
+    max_addresses: int
+
+
+class NintendontClient(GameCubeClient):
+    address: str | None
+    meta_info: NintendontMetaInfo | None
+    sock: socket.socket | None
+    logger: Logger
+
+    def __init__(self, logger: Logger):
+        self.address = None
+        self.meta_info = None
+        self.sock = None
+        self.logger = logger
+
+    def is_connected(self):
+        return self.address is not None and self.sock is not None
+
+    def set_address(self, new_address: str | None):
+        if new_address != self.address and self.is_connected():
+            self.logger.info("Nintendont address changed, disconnecting.")
+            self.disconnect()
+        self.address = new_address
+
+    def connect(self):
+        if self.address is None:
+            raise NintendontException("Address is not set")
+
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            self.sock.connect((self.address, NINTENDONT_PORT))
+        except OSError as e:
+            self.sock = None
+            raise NintendontException from e
+
+        data = struct.pack(">BBBB", NintendontMemoryOperationType.REQUEST_VERSION, 0, 0, True)
+        result = self.__write_to_socket(data)
+        self.meta_info = NintendontMetaInfo._make(struct.unpack(">IIII", result))
+        self.logger.debug(f"Protocol version: {self.meta_info.protocol_version}")
+        self.logger.debug(f"Max input bytes: {self.meta_info.max_input_bytes}")
+        self.logger.debug(f"Max output bytes: {self.meta_info.max_output_bytes}")
+        self.logger.debug(f"Max addresses: {self.meta_info.max_addresses}")
+
+    def disconnect(self):
+        if self.sock is not None:
+            self.sock.close()
+        self.sock = None
+        self.meta_info = None
+
+    def __request_operations(self, addresses: list[int], memory_operations: list[NintendontOperation]) -> list[bytes | None]:
+        if len(addresses) > self.meta_info.max_addresses:
+            raise NintendontException(f"Too many addresses: Max is {self.meta_info.max_addresses}, got {len(addresses)}")
+
+        data = bytearray()
+        data.extend(struct.pack(">BBBB", NintendontMemoryOperationType.READ_COMMANDS, len(memory_operations), len(addresses), True))
+        data.extend(itertools.chain.from_iterable(struct.pack(">I", address) for address in addresses))
+        data.extend(itertools.chain.from_iterable(operation.to_bytes() for operation in memory_operations))
+        if len(data) > self.meta_info.max_input_bytes:
+            self.logger.warning(f"Command too long: {data.hex()}")
+            raise NintendontException(f"Command too long: Max {self.meta_info.max_input_bytes} bytes, got {len(data)}")
+        response = self.__write_to_socket(data)
+
+        results: list[bytes | None] = []
+        current_index = ((len(memory_operations) - 1) // 8 + 1)
+        success_bytes = response[:current_index]
+        for i, op in enumerate(memory_operations):
+            index = i // 8
+            if success_bytes[index]:
+                if op.is_read():
+                    results.append(response[current_index:current_index + op.size])
+                else:
+                    results.append(b'')
+            else:
+                results.append(None)
+        return results
+
+    def __write_to_socket(self, data: bytes | bytearray) -> bytes:
+        assert self.sock is not None
+        try:
+            self.sock.send(data)
+            response = self.sock.recv(1024)
+            if response == b'':
+                self.disconnect()
+                raise NintendontException("Connection was closed")
+            return response
+        except OSError as e:
+            self.disconnect()
+            raise NintendontException from e
+
+    def read_pointer(self, pointer: int, offset: int, byte_count: int) -> Any:
+        return self.__request_operations([pointer], [NintendontOperation.make_read(0, byte_count, offset)])[0]
+
+    def read_address(self, address: int, bytes_to_read: int) -> Any:
+        result = self.__request_operations([address], [NintendontOperation.make_read(0, bytes_to_read)])[0]
+        if result == None:
+            raise NintendontException(f"{address:x} -> {address + bytes_to_read:x} is not a valid for GC memory")
+        return result
+
+    # TODO: Find out what dolphin memory engine write_bytes() returns to match DolphinClient behavior. Currently assumed
+    # to be the original value that was overwritten
+
+    def write_pointer(self, pointer: int, offset: int, data: Any):
+        return self.__request_operations([pointer], [NintendontOperation.make_write(True, 0, cast(bytes, data), offset)])[0]
+
+    def write_address(self, address: int, data: Any):
+        # FIXME: Only read_address() raises on bad address. NintendontClient has the same asymmetry to maintain the same
+        # behavior as DolphinClient
+        return self.__request_operations([address], [NintendontOperation.make_write(True, 0, cast(bytes, data))])[0]

--- a/GameCubeClient.py
+++ b/GameCubeClient.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from logging import Logger
 from typing import Any
 import dolphin_memory_engine  # type: ignore
@@ -7,11 +8,45 @@ import Utils
 GC_GAME_ID_ADDRESS = 0x80000000
 
 
-class DolphinException(Exception):
+class GameCubeException(Exception):
     pass
 
 
-class DolphinClient:
+class DolphinException(GameCubeException):
+    pass
+
+
+class GameCubeClient(ABC):
+    @abstractmethod
+    def is_connected(self):
+        ...
+
+    @abstractmethod
+    def connect(self):
+        ...
+
+    @abstractmethod
+    def disconnect(self):
+        ...
+
+    @abstractmethod
+    def read_pointer(self, pointer: int, offset: int, byte_count: int) -> Any:
+        ...
+
+    @abstractmethod
+    def read_address(self, address: int, bytes_to_read: int) -> Any:
+        ...
+
+    @abstractmethod
+    def write_pointer(self, pointer: int, offset: int, data: Any):
+        ...
+
+    @abstractmethod
+    def write_address(self, address: int, data: Any):
+        ...
+
+
+class DolphinClient(GameCubeClient):
     dolphin: dolphin_memory_engine  # type: ignore
     logger: Logger
 

--- a/MetroidPrimeClient.py
+++ b/MetroidPrimeClient.py
@@ -24,8 +24,8 @@ from .Items import suit_upgrade_table
 from .ClientReceiveItems import handle_receive_items
 from .NotificationManager import NotificationManager
 from .Container import construct_hook_patch
-from .DolphinClient import (
-    DolphinException,
+from .GameCubeClient import (
+    GameCubeException,
     assert_no_running_dolphin,
     get_num_dolphin_instances,
 )
@@ -207,7 +207,7 @@ async def dolphin_sync_task(ctx: MetroidPrimeContext):
                 await _handle_game_not_ready(ctx)
                 await asyncio.sleep(1)
         except Exception as e:
-            if isinstance(e, DolphinException):
+            if isinstance(e, GameCubeException):
                 logger.error(str(e))
             else:
                 logger.error(traceback.format_exc())

--- a/MetroidPrimeClient.py
+++ b/MetroidPrimeClient.py
@@ -297,7 +297,7 @@ async def _handle_game_not_ready(ctx: MetroidPrimeContext):
 
 
 async def run_game(romfile: str):
-    auto_start: bool = Utils.get_options()["metroidprime_options"].get(
+    auto_start: bool = Utils.get_settings()["metroidprime_options"].get(
         "rom_start", True
     )
 
@@ -370,7 +370,7 @@ def get_randomprime_config_from_apmp1(apmp1_file: str) -> Dict[str, Any]:
 
 async def patch_and_run_game(apmp1_file: str):
     apmp1_file = os.path.abspath(apmp1_file)
-    input_iso_path = Utils.get_options()["metroidprime_options"]["rom_file"]
+    input_iso_path = Utils.get_settings()["metroidprime_options"]["rom_file"]
     game_version = get_version_from_iso(input_iso_path)
     base_name = os.path.splitext(apmp1_file)[0]
     output_path = base_name + ".iso"

--- a/MetroidPrimeClient.py
+++ b/MetroidPrimeClient.py
@@ -137,10 +137,7 @@ class MetroidPrimeContext(CommonContext):
     ):
         super().__init__(server_address, password)
         self.game_interface = MetroidPrimeInterface(logger)
-        self.notification_manager = NotificationManager(
-            # FIXME
-            HUD_MESSAGE_DURATION, lambda message: Utils.async_start(self.game_interface.send_hud_message(message))
-        )
+        self.notification_manager = NotificationManager(HUD_MESSAGE_DURATION, self.game_interface.send_hud_message)
         self.apmp1_file = apmp1_file
 
     def on_deathlink(self, data: Utils.Dict[str, Utils.Any]) -> None:
@@ -276,7 +273,7 @@ async def _handle_game_ready(ctx: MetroidPrimeContext):
         await ctx.game_interface.update_relay_tracker_cache()
         current_inventory = await ctx.game_interface.get_current_inventory()
         await handle_receive_items(ctx, current_inventory)
-        ctx.notification_manager.handle_notifications()
+        await ctx.notification_manager.handle_notifications()
         await handle_checked_location(ctx, current_inventory)
         await handle_check_goal_complete(ctx)
         await handle_tracker_level(ctx)

--- a/MetroidPrimeClient.py
+++ b/MetroidPrimeClient.py
@@ -213,7 +213,7 @@ async def game_sync_task(ctx: MetroidPrimeContext):
             if ctx.nintendont_ip is not None and not ctx.has_sent_nintendont_warning:
                 logger.warning("Nintendont support is experimental. You may experience bugs or poor performance.")
                 ctx.has_sent_nintendont_warning = True
-            await ctx.game_interface.set_nintendont_ip(ctx.nintendont_ip)
+            ctx.game_interface.set_nintendont_ip(ctx.nintendont_ip)
 
             connection_state = await ctx.game_interface.get_connection_state()
             update_connection_status(ctx, connection_state)

--- a/MetroidPrimeInterface.py
+++ b/MetroidPrimeInterface.py
@@ -206,16 +206,16 @@ class MetroidPrimeInterface:
         self.logger = logger
         self.gamecube_client = DolphinClient(logger)
 
-    async def set_nintendont_ip(self, address: str | None):
+    def set_nintendont_ip(self, address: str | None):
         if address is None and type(self.gamecube_client) is NintendontClient:
-            await self.gamecube_client.disconnect()
+            self.gamecube_client.disconnect()
             self.gamecube_client = DolphinClient(self.logger)
         elif address is not None and type(self.gamecube_client) is DolphinClient:
-            await self.gamecube_client.disconnect()
+            self.gamecube_client.disconnect()
             self.gamecube_client = NintendontClient(self.logger)
         if address is not None:
             assert type(self.gamecube_client) is NintendontClient
-            await self.gamecube_client.set_address(address)
+            self.gamecube_client.set_address(address)
 
     async def give_item_to_player(
         self,
@@ -444,7 +444,7 @@ class MetroidPrimeInterface:
             pass
 
     async def disconnect_from_game(self):
-        await self.gamecube_client.disconnect()
+        self.gamecube_client.disconnect()
         self.logger.info(f"Disconnected from {'Dolphin Emulator' if type(self.gamecube_client) is DolphinClient else 'Nintendont'}")
 
     async def get_connection_state(self):

--- a/MetroidPrimeInterface.py
+++ b/MetroidPrimeInterface.py
@@ -478,12 +478,7 @@ class MetroidPrimeInterface:
             encoded_message += b"\x00" * num_to_align
 
         assert self.current_game
-        # Nintendont can receive a limited amount of data at a time so send message in 64-byte chunks
-        # TODO: Abstract this away in the NintendontClient somehow
-        for i in range(0, len(encoded_message), 64):
-            await self.gamecube_client.write_address(
-                GAMES[self.current_game]["HUD_MESSAGE_ADDRESS"] + i, encoded_message[i:i + 64]
-            )
+        await self.gamecube_client.write_address(GAMES[self.current_game]["HUD_MESSAGE_ADDRESS"], encoded_message)
 
     def __progressive_beam_to_beam(
         self, charge_beam: SuitUpgrade

--- a/MetroidPrimeInterface.py
+++ b/MetroidPrimeInterface.py
@@ -468,9 +468,12 @@ class MetroidPrimeInterface:
             encoded_message += b"\x00" * num_to_align
 
         assert self.current_game
-        await self.gamecube_client.write_address(
-            GAMES[self.current_game]["HUD_MESSAGE_ADDRESS"], encoded_message
-        )
+        # Nintendont can receive a limited amount of data at a time so send message in 64-byte chunks
+        # TODO: Abstract this away in the NintendontClient somehow
+        for i in range(0, len(encoded_message), 64):
+            await self.gamecube_client.write_address(
+                GAMES[self.current_game]["HUD_MESSAGE_ADDRESS"] + i, encoded_message[i:i + 64]
+            )
 
     def __progressive_beam_to_beam(
         self, charge_beam: SuitUpgrade

--- a/NotificationManager.py
+++ b/NotificationManager.py
@@ -1,5 +1,5 @@
 import time
-from typing import Callable, List
+from typing import Any, Callable, Coroutine, List
 
 
 class NotificationManager:
@@ -7,10 +7,10 @@ class NotificationManager:
     time_since_last_message: float = 0
     last_message_time: float = 0
     message_duration: float
-    send_notification_func: Callable[[str], bool]
+    send_notification_func: Callable[[str], Coroutine[Any, Any, bool]]
 
     def __init__(
-        self, message_duration: float, send_notification_func: Callable[[str], bool]
+        self, message_duration: float, send_notification_func: Callable[[str], Coroutine[Any, Any, bool]]
     ):
         self.message_duration = (
             message_duration / 2
@@ -20,14 +20,14 @@ class NotificationManager:
     def queue_notification(self, message: str):
         self.notification_queue.append(message)
 
-    def handle_notifications(self):
+    async def handle_notifications(self):
         self.time_since_last_message = time.time() - self.last_message_time
         if (
             len(self.notification_queue) > 0
             and self.time_since_last_message >= self.message_duration
         ):
             notification = self.notification_queue[0]
-            result = self.send_notification_func(notification)
+            result = await self.send_notification_func(notification)
             if result:
                 self.notification_queue.pop(0)
                 self.last_message_time = time.time()

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Multiworld items appear as one of the following:
 
 ### What versions of the Metroid Prime are supported?
 
-Only the GameCube versions of the game are supported.  
-The Wii and Switch version of the game are _not_ supported.  
+Only the GameCube versions of the game are supported.
+The Wii and Switch version of the game are _not_ supported.
 
 ### When the player receives an item, what happens?
 
@@ -51,7 +51,7 @@ To warp to the starting location,
 3. While choosing No, simultaenously hold down the L and R buttons.
 
 ### What happens to my own collected items at Game Over or if the game is reset without saving?
-As long as the game is connected to the Client and the Client is connected to the server, items you collected before the Game Over or reset will be kept and returned to you when you re-enter the game, even if you did not save.  
+As long as the game is connected to the Client and the Client is connected to the server, items you collected before the Game Over or reset will be kept and returned to you when you re-enter the game, even if you did not save.
 (The item dot indicators on the map will still show the item location as not collected, even if the Client gives the items back to you.)
 
 ### What Metroid Prime mods/tools does this work with?
@@ -62,6 +62,7 @@ It is recommended to use a vanilla ISO with the latest release of [Dolphin](http
   - [PrimeHack](https://forums.dolphin-emu.org/Thread-fork-primehack-fps-controls-and-more-for-metroid-prime)
   - [Widescreen HUD Mod](<https://wiki.dolphin-emu.org/index.php?title=Metroid_Prime_(GC)#16:9_HUD_Mod>) (Revision 0 "0-00" only)
   - [MPItemTracker](https://github.com/UltiNaruto/MPItemTracker)
+  - [Nintendont-Multiworld](https://github.com/randovania/Nintendont)
 - Not compatible
   - Practice Mod (The AP client is unable to connect to the game with this mod present.)
 

--- a/__init__.py
+++ b/__init__.py
@@ -96,8 +96,15 @@ class MetroidPrimeSettings(settings.Group):
         Alternatively, set it to a path to a program to open the .iso file with (like Dolplhin)
         """
 
+    class NintendontAddress(str):
+        """
+        Set this to null to connect the client to Dolphin by default.
+        Set it to your Wii or Wii U's IP address to connect to it using Nintendont when the client starts.
+        """
+
     rom_file: RomFile = RomFile(RomFile.copy_to)
     rom_start: typing.Union[RomStart, bool] = False
+    nintendont_address: typing.Optional[NintendontAddress] = None
 
 
 class MetroidPrimeWeb(WebWorld):


### PR DESCRIPTION
Allows the client to connect to Nintendont to play on a real Wii or Wii U.

The actual implementation for the Nintendont connection was fairly easy because Dolphin interactions were already handled by a class, for which I made a new abstract base class. However, it had to be converted to async to work because a plain old socket would lag the client because of the blocking I/O.

You can connect to Nintendont by using a client command, or by setting your console's IP as your default GCN connection in host.yaml. Unsure whether to include a client command to save the IP as default or just expect to modify host.yaml for it.

In its current state, this seems to work pretty smoothly, although the client's operations can take a while to go through. The way some of the data is read (mainly the inventory) has been changed to reduce turnaround time to pretty reasonable levels, but there is still occasional delay caused by the time it takes run the game watcher loop.

Unsure if there should be more messages indicating the status of connection attempts, as there are no messages indicating the reason for failed connection attempts (so it's not clear if something's wrong, and from my other experiments my Wii U has trouble connecting to the network in Nintendont sometimes).

~~I also weirdly ran into an issue where the Cargo Freight Lift to Deck Gamma location just wouldn't register? I ran into a silent connection error, got Burn Dome, Cargo Freight Lift, and then Frigate Crash Site, then restarted everything. On reconnecting, Cargo Freight Lift failed to register even though both of the other rooms' locations registered fine. No idea what happened there.~~ This was probably caused by the original faulty error handling.