### PR TITLE
Add item models for other Metroid games

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ All suit upgrades and expansion items can be shuffled in other players' worlds, 
 
 ### What does another world's item look like in Metroid Prime?
 
-Multiworld items appear as one of the following:
+Items for other Metroid games appear as their counterparts in Metroid Prime where applicable. Otherwise, multiworld
+items appear as one of the following:
 
 - Progression Item: Cog
 - Useful Item: Metroid Model with a random texture

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Items for other Metroid games appear as their counterparts in Metroid Prime wher
 items appear as one of the following:
 
 - Progression Item: Cog
-- Useful Item: Metroid Model with a random texture
-- Filler Item: Zoomer Model with a random texture
+- Useful Item: Zoomer model with a random texture
+- Filler Item: Metroid model with a random texture
 
 ### What versions of the Metroid Prime are supported?
 

--- a/data/ItemModels.py
+++ b/data/ItemModels.py
@@ -8,7 +8,7 @@ class ItemModel(StrEnum):
     WaveBeam = "Wave Beam"
     PlasmaBeam = "Plasma Beam"
     Missile = "Missile"
-    ShinyMissile = "ShinyMissile"
+    ShinyMissile = "Shiny Missile"
     ScanVisor = "Scan Visor"
     MorphBallBomb = "Morph Ball Bomb"
     PowerBombExpansion = "Power Bomb Expansion"

--- a/data/ItemModels.py
+++ b/data/ItemModels.py
@@ -30,10 +30,23 @@ class ItemModel(StrEnum):
     EnergyTank = "Energy Tank"
     Wavebuster = "Wavebuster"
     PowerBomb = "Power Bomb"
+    ArtifactTruth = "Artifact of Truth"
+    ArtifactStrength = "Artifact of Strength"
+    ArtifactElder = "Artifact of Elder"
+    ArtifactWild = "Artifact of Wild"
+    ArtifactLifegiver = "Artifact of Lifegiver"
+    ArtifactWarrior = "Artifact of Warrior"
+    ArtifactChozo = "Artifact of Chozo"
+    ArtifactNature = "Artifact of Nature"
+    ArtifactSun = "Artifact of Sun"
+    ArtifactWorld = "Artifact of World"
+    ArtifactSpirit = "Artifact of Spirit"
+    ArtifactNewborn = "Artifact of Newborn"
     Cog = "Cog"
     GameCube = "GameCube"
     Zoomer = "Zoomer"
     Metroid = "Nothing"
+
 
 native_item_mapping: dict[str, str] = {
     SuitUpgrade.Missile_Expansion.value: ItemModel.Missile,
@@ -45,6 +58,7 @@ native_item_mapping: dict[str, str] = {
     ProgressiveUpgrade.Progressive_Ice_Beam.value: ItemModel.IceBeam,
     ProgressiveUpgrade.Progressive_Plasma_Beam.value: ItemModel.PlasmaBeam,
 }
+
 
 remote_item_mapping: dict[tuple[str, str], str] = {
     ("Super Metroid", "Energy Tank"): ItemModel.EnergyTank,
@@ -124,4 +138,26 @@ remote_item_mapping: dict[tuple[str, str], str] = {
     # ("Metroid Zero Mission", "Speed Booster"): ItemModel.BoostBall,
     # ("Metroid Zero Mission", "Hi-Jump"): ItemModel.SpaceJumpBoots,
     ("Metroid Zero Mission", "Space Jump"): ItemModel.SpaceJumpBoots,
+
+    ("Metroid Fusion", "Missile Data"): ItemModel.ShinyMissile,
+    ("Metroid Fusion", "Morph Ball"): ItemModel.MorphBall,
+    ("Metroid Fusion", "Charge Beam"): ItemModel.ChargeBeam,
+    ("Metroid Fusion", "Bomb Data"): ItemModel.MorphBallBomb,
+    # ("Metroid Fusion", "Hi-Jump"): ItemModel.SpaceJumpBoots,
+    # ("Metroid Fusion", "Speed Booster"): ItemModel.BoostBall,
+    ("Metroid Fusion", "Super Missile"): ItemModel.SuperMissile,
+    ("Metroid Fusion", "Varia Suit"): ItemModel.VariaSuit,
+    ("Metroid Fusion", "Ice Missile"): ItemModel.IceSpreader,  # Supers?
+    ("Metroid Fusion", "Wide Beam"): ItemModel.SuperMissile,
+    ("Metroid Fusion", "Power Bomb Data"): ItemModel.PowerBomb,
+    ("Metroid Fusion", "Space Jump"): ItemModel.SpaceJumpBoots,
+    ("Metroid Fusion", "Plasma Beam"): ItemModel.PlasmaBeam,
+    ("Metroid Fusion", "Gravity Suit"): ItemModel.GravitySuit,
+    ("Metroid Fusion", "Diffusion Missile"): ItemModel.IceSpreader,  # Supers? Wavebuster?
+    ("Metroid Fusion", "Wave Beam"): ItemModel.WaveBeam,
+    ("Metroid Fusion", "Ice Beam"): ItemModel.IceBeam,
+    ("Metroid Fusion", "Missile Tank"): ItemModel.Missile,
+    ("Metroid Fusion", "Energy Tank"): ItemModel.EnergyTank,
+    ("Metroid Fusion", "Power Bomb Tank"): ItemModel.PowerBombExpansion,
+    # ("Metroid Fusion", "Infant Metroid"): ItemModel.ArtifactNewborn,
 }

--- a/data/ItemModels.py
+++ b/data/ItemModels.py
@@ -1,0 +1,127 @@
+from enum import StrEnum
+
+from ..Items import ProgressiveUpgrade, SuitUpgrade
+
+
+class ItemModel(StrEnum):
+    IceBeam = "Ice Beam"
+    WaveBeam = "Wave Beam"
+    PlasmaBeam = "Plasma Beam"
+    Missile = "Missile"
+    ShinyMissile = "ShinyMissile"
+    ScanVisor = "Scan Visor"
+    MorphBallBomb = "Morph Ball Bomb"
+    PowerBombExpansion = "Power Bomb Expansion"
+    Flamethrower = "Flamethrower"
+    ThermalVisor = "Thermal Visor"
+    ChargeBeam = "Charge Beam"
+    SuperMissile = "Super Missile"
+    GrappleBeam = "Grapple Beam"
+    XRayVisor = "X-Ray Visor"
+    IceSpreader = "Ice Spreader"
+    SpaceJumpBoots = "Space Jump Boots"
+    MorphBall = "Morph Ball"
+    CombatVisor = "Combat Visor"
+    BoostBall = "Boost Ball"
+    SpiderBall = "Spider Ball"
+    GravitySuit = "Gravity Suit"
+    VariaSuit = "Varia Suit"
+    PhazonSuit = "Phazon Suit"
+    EnergyTank = "Energy Tank"
+    Wavebuster = "Wavebuster"
+    PowerBomb = "Power Bomb"
+    Cog = "Cog"
+    GameCube = "GameCube"
+    Zoomer = "Zoomer"
+    Metroid = "Nothing"
+
+native_item_mapping: dict[str, str] = {
+    SuitUpgrade.Missile_Expansion.value: ItemModel.Missile,
+    SuitUpgrade.Missile_Launcher.value: ItemModel.ShinyMissile,
+    SuitUpgrade.Main_Power_Bomb.value: ItemModel.PowerBomb,
+    SuitUpgrade.Power_Beam.value: ItemModel.SuperMissile,
+    ProgressiveUpgrade.Progressive_Power_Beam.value: ItemModel.SuperMissile,
+    ProgressiveUpgrade.Progressive_Wave_Beam.value: ItemModel.WaveBeam,
+    ProgressiveUpgrade.Progressive_Ice_Beam.value: ItemModel.IceBeam,
+    ProgressiveUpgrade.Progressive_Plasma_Beam.value: ItemModel.PlasmaBeam,
+}
+
+remote_item_mapping: dict[tuple[str, str], str] = {
+    ("Super Metroid", "Energy Tank"): ItemModel.EnergyTank,
+    ("Super Metroid", "Missile"): ItemModel.Missile,
+    ("Super Metroid", "Super Missile"): ItemModel.ShinyMissile,  # Preferred over Prime super missile model, or nothing?
+    ("Super Metroid", "Power Bomb"): ItemModel.PowerBombExpansion,
+    ("Super Metroid", "Bomb"): ItemModel.MorphBallBomb,
+    ("Super Metroid", "Charge Beam"): ItemModel.ChargeBeam,
+    ("Super Metroid", "Ice Beam"): ItemModel.IceBeam,
+    # ("Super Metroid", "Hi-Jump Boots"): ItemModel.SpaceJumpBoots,  # Maybe?
+    # ("Super Metroid", "Speed Booster"): ItemModel.BoostBall,  # Feels too different
+    ("Super Metroid", "Wave Beam"): ItemModel.WaveBeam,
+    ("Super Metroid", "Spazer Beam"): ItemModel.SuperMissile,  # Similar reasoning to Power Beam
+    ("Super Metroid", "Varia Suit"): ItemModel.VariaSuit,
+    ("Super Metroid", "Plasma Beam"): ItemModel.PlasmaBeam,
+    ("Super Metroid", "Grappling Beam"): ItemModel.GrappleBeam,
+    ("Super Metroid", "Morph Ball"): ItemModel.MorphBall,
+    # ("Super Metroid", "Reserve Tank"): ItemModel.EnergyTank,
+    ("Super Metroid", "Gravity Suit"): ItemModel.GravitySuit,
+    # ("Super Metroid", "X-Ray Scope"): ItemModel.XRayVisor,
+    ("Super Metroid", "Space Jump"): ItemModel.SpaceJumpBoots,
+
+    ("SMZ3", "Missile"): ItemModel.Missile,
+    ("SMZ3", "Super"): ItemModel.ShinyMissile,
+    ("SMZ3", "PowerBomb"): ItemModel.PowerBombExpansion,
+    ("SMZ3", "Grapple"): ItemModel.GrappleBeam,
+    # ("SMZ3", "XRay"): ItemModel.XRayVisor,
+    ("SMZ3", "ETank"): ItemModel.EnergyTank,
+    # ("SMZ3", "ReserveTank"): ItemModel.EnergyTank,
+    ("SMZ3", "Charge"): ItemModel.ChargeBeam,
+    ("SMZ3", "Ice"): ItemModel.IceBeam,
+    ("SMZ3", "Wave"): ItemModel.WaveBeam,
+    ("SMZ3", "Spazer"): ItemModel.SuperMissile,
+    ("SMZ3", "Plasma"): ItemModel.PlasmaBeam,
+    ("SMZ3", "Varia"): ItemModel.VariaSuit,
+    ("SMZ3", "Gravity"): ItemModel.GravitySuit,
+    ("SMZ3", "Morph"): ItemModel.MorphBall,
+    ("SMZ3", "Bombs"): ItemModel.MorphBallBomb,
+    ("SMZ3", "SpaceJump"): ItemModel.SpaceJumpBoots,
+    # ("SMZ3", "HiJump"): ItemModel.SpaceJumpBoots,
+    # ("SMZ3", "SpeedBooster"): ItemModel.BoostBall,
+
+    ("Super Metroid Map Rando", "ETank"): ItemModel.EnergyTank,
+    ("Super Metroid Map Rando", "Missile"): ItemModel.Missile,
+    ("Super Metroid Map Rando", "Super"): ItemModel.ShinyMissile,
+    ("Super Metroid Map Rando", "PowerBomb"): ItemModel.PowerBombExpansion,
+    ("Super Metroid Map Rando", "Bombs"): ItemModel.MorphBallBomb,
+    ("Super Metroid Map Rando", "Charge"): ItemModel.ChargeBeam,
+    ("Super Metroid Map Rando", "Ice"): ItemModel.IceBeam,
+    # ("Super Metroid Map Rando", "HiJump"): ItemModel.SpaceJumpBoots,
+    # ("Super Metroid Map Rando", "SpeedBooster"): ItemModel.BoostBall,
+    ("Super Metroid Map Rando", "Wave"): ItemModel.WaveBeam,
+    ("Super Metroid Map Rando", "Spazer"): ItemModel.SuperMissile,
+    ("Super Metroid Map Rando", "Varia"): ItemModel.VariaSuit,
+    ("Super Metroid Map Rando", "Gravity"): ItemModel.GravitySuit,
+    # ("Super Metroid Map Rando", "XRay"): ItemModel.XRayVisor,
+    ("Super Metroid Map Rando", "Plasma"): ItemModel.PlasmaBeam,
+    ("Super Metroid Map Rando", "Grapple"): ItemModel.GrappleBeam,
+    ("Super Metroid Map Rando", "SpaceJump"): ItemModel.SpaceJumpBoots,
+    ("Super Metroid Map Rando", "Morph"): ItemModel.MorphBall,
+    # ("Super Metroid Map Rando", "ReserveTank"): ItemModel.EnergyTank,
+    # ("Super Metroid Map Rando", "WallJump"): ItemModel.SpaceJumpBoots,
+
+    ("Metroid Zero Mission", "Energy Tank"): ItemModel.EnergyTank,
+    ("Metroid Zero Mission", "Missile Tank"): ItemModel.Missile,
+    ("Metroid Zero Mission", "Super Missile Tank"): ItemModel.ShinyMissile,
+    ("Metroid Zero Mission", "Power Bomb Tank"): ItemModel.PowerBombExpansion,
+    ("Metroid Zero Mission", "Long Beam"): ItemModel.SuperMissile,
+    ("Metroid Zero Mission", "Charge Beam"): ItemModel.ChargeBeam,
+    ("Metroid Zero Mission", "Ice Beam"): ItemModel.IceBeam,
+    ("Metroid Zero Mission", "Wave Beam"): ItemModel.WaveBeam,
+    ("Metroid Zero Mission", "Plasma Beam"): ItemModel.PlasmaBeam,
+    ("Metroid Zero Mission", "Bomb"): ItemModel.MorphBallBomb,
+    ("Metroid Zero Mission", "Varia Suit"): ItemModel.VariaSuit,
+    ("Metroid Zero Mission", "Gravity Suit"): ItemModel.GravitySuit,
+    ("Metroid Zero Mission", "Morph Ball"): ItemModel.MorphBall,
+    # ("Metroid Zero Mission", "Speed Booster"): ItemModel.BoostBall,
+    # ("Metroid Zero Mission", "Hi-Jump"): ItemModel.SpaceJumpBoots,
+    ("Metroid Zero Mission", "Space Jump"): ItemModel.SpaceJumpBoots,
+}

--- a/data/RoomData.py
+++ b/data/RoomData.py
@@ -28,6 +28,7 @@ from ..Locations import MetroidPrimeLocation, every_location
 from .RoomNames import RoomName
 from .Tricks import TrickInfo
 from .DoorData import DoorData
+from .ItemModels import ItemModel, native_item_mapping, remote_item_mapping
 
 if typing.TYPE_CHECKING:
     from .. import MetroidPrimeWorld
@@ -51,31 +52,20 @@ def get_config_item_text(world: "MetroidPrimeWorld", location: str) -> str:
 def get_config_item_model(world: "MetroidPrimeWorld", location: str) -> str:
     loc = world.get_location(location)
     assert loc.item
+    name = loc.item.name
+
     if loc.native_item:
-        name = loc.item.name
-        if name == SuitUpgrade.Missile_Expansion.value:
-            return "Missile"
-        if name == SuitUpgrade.Missile_Launcher.value:
-            return "Shiny Missile"
-        if name == SuitUpgrade.Main_Power_Bomb.value:
-            return "Power Bomb"
-        if (
-            name == ProgressiveUpgrade.Progressive_Power_Beam.value
-            or name == SuitUpgrade.Power_Beam.value
-        ):
-            return "Super Missile"
-        if name == ProgressiveUpgrade.Progressive_Wave_Beam.value:
-            return "Wave Beam"
-        if name == ProgressiveUpgrade.Progressive_Ice_Beam.value:
-            return "Ice Beam"
-        if name == ProgressiveUpgrade.Progressive_Plasma_Beam.value:
-            return "Plasma Beam"
-        return name
+        return native_item_mapping.get(name, name)
+
+    model = remote_item_mapping.get((loc.item.game, name), None)
+    if model is not None:
+        return model
+
     if loc.item.advancement:
-        return "Cog"
+        return ItemModel.Cog
     if loc.item.useful or loc.item.trap:
-        return "Zoomer"
-    return "Nothing"
+        return ItemModel.Zoomer
+    return ItemModel.Metroid
 
 
 @dataclass


### PR DESCRIPTION
Allows the game to display item models for items from Super Metroid, Metroid Fusion, and Metroid: Zero Mission.

The mappings have some commented out entries for items that could fit but I didn't feel sure about. These range from "would almost definitely work" to "probably not."

Feel free to merge this with or without the mappings for the unsupported Map Rando, Fusion, and Zero Mission items.