### PR TITLE
Docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ All suit upgrades and expansion items can be shuffled in other players' worlds, 
 
 ### What does another world's item look like in Metroid Prime?
 
-Multiworld items appear as one of the following:
+Multiworld item pickups appear as one of the following:
 
 - Progression Item: Cog
-- Useful Item: Metroid Model with a random texture
-- Filler Item: Zoomer Model with a random texture
+- Useful or Trap Item: Zoomer model with a random texture
+- Filler Item: Metroid model with a random texture
 
 ### What versions of the Metroid Prime are supported?
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # Metroid Prime Archipelago
 
+To get started or for troubleshooting, see **[the Setup Guide](./docs/setup_en.md)**!
+
 An Archipelago implementation of Metroid Prime multiworld randomizer using [randomprime](https://github.com/randovania/randomprime/)
-
-## Setup Guide
-
-To get started or for troubleshooting, see [the Setup Guide](./docs/setup_en.md).
 
 ## Info
 ### What does randomization do to this game?

--- a/README.md
+++ b/README.md
@@ -54,17 +54,6 @@ To warp to the starting location,
 As long as the game is connected to the Client and the Client is connected to the server, items you collected before the Game Over or reset will be kept and returned to you when you re-enter the game, even if you did not save.  
 (The item dot indicators on the map will still show the item location as not collected, even if the Client gives the items back to you.)
 
-### What Metroid Prime mods/tools does this work with?
-
-It is recommended to use a vanilla ISO with the latest release of [Dolphin](https://dolphin-emu.org/download/#).
-
-- Not thoroughly tested; but some users report that these tools and mods work
-  - [PrimeHack](https://forums.dolphin-emu.org/Thread-fork-primehack-fps-controls-and-more-for-metroid-prime)
-  - [Widescreen HUD Mod](<https://wiki.dolphin-emu.org/index.php?title=Metroid_Prime_(GC)#16:9_HUD_Mod>) (Revision 0 "0-00" only)
-  - [MPItemTracker](https://github.com/UltiNaruto/MPItemTracker)
-- Not compatible
-  - Practice Mod (The AP client is unable to connect to the game with this mod present.)
-
 ### Aside from item locations being shuffled, how does this differ from the vanilla game?
 
 Some of the changes include:

--- a/docs/setup_en.md
+++ b/docs/setup_en.md
@@ -10,6 +10,7 @@ The following are required in order to play _Metroid Prime_ in Archipelago:
 - [Archipelago](https://github.com/ArchipelagoMW/Archipelago/releases)
 - [Dolphin Emulator](https://dolphin-emu.org/download/). We recommend the latest Release version.
 - A _Metroid Prime_ (GameCube version) ISO file
+  - This must be a full standard ISO. "Compressed ISO", "ciso", or "nkit.iso" will **not** work.
   - Any official release copy of the GameCube version will work. (All region versions are compatible, including all three versions of NTSC-USA)
   - The Wii and Switch version of the game are _not_ supported.
 
@@ -110,11 +111,11 @@ Once you do, follow these steps to connect to the room:
   - Start the Metroid Prime Client and Dolphin in a Specific Order
 
     - For some users, connecting to the AP server before letting the Metroid Prime client causes connection issues.
-      Try starting the game in this order:
-      1.) Start the Metroid Prime client
-      2.) Start Dolphin and start the game (if it launches automatically, that's fine)
-      3.) Select or create a save file and enter the game
-      4.) Enter the AP server address into the Metroid Prime Client
+      Try starting the game in this order:  
+      1.) Start the Metroid Prime client  
+      2.) Start Dolphin and start the game (if it launches automatically, that's fine)  
+      3.) Select or create a save file and enter the game  
+      4.) Enter the AP server address into the Metroid Prime Client  
 
   - For Linux, use Dolphin FlatPak
     - Install Dolphin Emulator from [Flathub](https://flathub.org/apps/org.DolphinEmu.dolphin-emu)
@@ -129,3 +130,4 @@ Once you do, follow these steps to connect to the room:
 
 In the offical [Archipelago Discord](https://discord.com/invite/8Z65BR2) under the `future-game-design` channel, there is a [_Metroid Prime_ thread](https://discord.com/channels/731205301247803413/1172631093837570068).
 Feel free to ping `@Electro15` or `@hesto2` with any bugs/thoughts/complaints/wishes/jokes you may have!
+

--- a/docs/setup_en.md
+++ b/docs/setup_en.md
@@ -8,7 +8,6 @@ This has only been tested on Windows, but feel free to let us know if you get th
 The following are required in order to play _Metroid Prime_ in Archipelago:
 
 - [Archipelago](https://github.com/ArchipelagoMW/Archipelago/releases)
-   For Archipelago 5.0/5.1, see the Note about Python versions in [APWorld Installation](#apworld-installation)
 - [Dolphin Emulator](https://dolphin-emu.org/download/). We recommend the latest Release version.
 - A _Metroid Prime_ (GameCube version) ISO file
   - Any official release copy of the GameCube version will work. (All region versions are compatible, including all three versions of NTSC-USA)

--- a/docs/setup_en.md
+++ b/docs/setup_en.md
@@ -20,17 +20,6 @@ The following are required in order to play _Metroid Prime_ in Archipelago:
 2. Unzip the downloaded Metroid Prime APWorld zip file and extract its files.
 3. In the Archipelago Launcher, select `Install APWorld`, and then select `metroidprime.apworld` file from the previous step.
 
->[!NOTE]
-> Because Archipelago 5.1 on Windows transitioned to using Python 3.12, current releases of Metroid Prime AP offers two options to download:
-> | Archipelago Version                                       |                                              |
-> |-----------------------------------------------------------|----------------------------------------------|
-> | Archipelago 5.1 or later for Windows                      | Download APWorld file ending with `3.12.zip`.|
-> | Archipelago 5.0 or earlier for Windows                    | Download APWorld file ending with `3.11.zip`.|
-> | Archipelago 6.0 or later AppImage for Linux               | Download APWorld file ending with `3.12.zip`.|
-> | Archipelago 5.1 or earlier AppImage for Linux             | Download APWorld file ending with `3.11.zip`.|
->
->  Future versions after Metroid Prime AP 0.4.9 will likely target only Python 3.12 and will only work on Archipelago 5.1 or newer.
-
 ## Setting Up Player Options YAML File
 
 All players playing _Metroid Prime_ must provide the room host with a YAML file containing the player options for their world.
@@ -78,48 +67,48 @@ Once you do, follow these steps to connect to the room:
 ## Troubleshooting
 
 ### General Troubleshooting Tips
-- Use the latest Metroid Prime Archipelago release
-  - Metroid Prime Archipelago: [Releases · Electro1512_MetroidAPrime](https://github.com/Electro1512/MetroidAPrime/releases)
+Use the latest Metroid Prime Archipelago release
+- Metroid Prime Archipelago: [Releases · Electro1512_MetroidAPrime](https://github.com/Electro1512/MetroidAPrime/releases)
 
 - Use the latest Dolphin Emulator Release: [Dolphin Emulator - Download](https://dolphin-emu.org/download/)
 
 ### Generating and Patching Troubleshooting
 
-- If you do not see the client in the Archipelago Launcher
-  - Ensure you have your `metroidprime.apworld` in the correct folder (The `custom_worlds` folder).
-  - Go to `%TEMP%` (C:\Users\<Username>\AppData\Local\Temp) and delete the folder `ap_metroidprime_temp_lib_vX.Y.Z`. Then restart the Archipelago Launcher.
+If you do not see the client in the Archipelago Launcher
+- Ensure you have your `metroidprime.apworld` in the correct folder (The `custom_worlds` folder).
+- Go to `%TEMP%` (C:\Users\<Username>\AppData\Local\Temp) and delete the folder `ap_metroidprime_temp_lib_vX.Y.Z`. Then restart the Archipelago Launcher.
 
-- If you receive this error in a dialog box after opening the AP_XXXXX_PX.apmp1 file:
-  > Count Mount File
-  > The disc image is corrupted.
+If you receive this error in a dialog box after opening the AP_XXXXX_PX.apmp1 file:
+> Count Mount File
+> The disc image is corrupted.
 
-  This is not an error related to the patcher - this is Windows File Explorer attempting to mount the GameCube ISO as a removable drive. It's likely that the patcher did sucessfully patch the game.
-  See if the patched ISO exists (often named AP_XXXXX_PX.iso). If it does, you can load it manually in Dolphin.
+This is not an error related to the patcher - this is Windows File Explorer attempting to mount the GameCube ISO as a removable drive. It's likely that the patcher did sucessfully patch the game.
+See if the patched ISO exists (often named AP_XXXXX_PX.iso). If it does, you can load it manually in Dolphin.
 
 ### Connection Troubleshooting
-- I have the randomized game open in Dolphin, but the Metroid Prime client says it can't connect to it!
-  - Make Sure the ISO is Randomized
-    - On the Main Menu, "Archipelago Metroid Prime" text should appear. ([image example](https://i.imgur.com/W6172zf.png))
-  - Ensure Only One Instance of Dolphin is Running
-    - Check Task Manager to see if there's multiple emulator instances running.
-    - You can also just restart your computer to be sure.
+I have the randomized game open in Dolphin, but the Metroid Prime client says it can't connect to it!
+- Make Sure the ISO is Randomized
+  - On the Main Menu, "Archipelago Metroid Prime" text should appear. ([image example](https://i.imgur.com/W6172zf.png))
+- Ensure Only One Instance of Dolphin is Running
+  - Check Task Manager to see if there's multiple emulator instances running.
+  - You can also just restart your computer to be sure.
 
-  - Disable Emulated Memory Size Override
-    - In Dolphin,
-      Config -> Advanced tab,
-      **Uncheck** Enable Emulated Memory Size Override
-  - Start the Metroid Prime Client and Dolphin in a Specific Order
+- Disable Emulated Memory Size Override
+  - In Dolphin,
+    Config -> Advanced tab,
+    **Uncheck** Enable Emulated Memory Size Override
+- Start the Metroid Prime Client and Dolphin in a Specific Order
 
-    - For some users, connecting to the AP server before letting the Metroid Prime client causes connection issues.
-      Try starting the game in this order:  
-      1.) Start the Metroid Prime client  
-      2.) Start Dolphin and start the game (if it launches automatically, that's fine)  
-      3.) Select or create a save file and enter the game  
-      4.) Enter the AP server address into the Metroid Prime Client  
+  - For some users, connecting to the AP server before letting the Metroid Prime client causes connection issues.
+    Try starting the game in this order:  
+    [1] Start the Metroid Prime client  
+    [2] Start Dolphin and start the game (if it launches automatically, that's fine)  
+    [3] Select or create a save file and enter the game  
+    [4] Enter the AP server address into the Metroid Prime Client  
 
-  - For Linux, use Dolphin FlatPak
-    - Install Dolphin Emulator from [Flathub](https://flathub.org/apps/org.DolphinEmu.dolphin-emu)
-    - Dolphin Memory Engine, as part of the Prime AP Client, can not access regular Dolphin's process but can access Flatpak's containerized Dolphin's process
+- For Linux, use Dolphin FlatPak
+  - Install Dolphin Emulator as a Flatpak (Linux users can add the following Flatpak repository: `https://flatpak.dolphin-emu.org/releases.flatpakrepo`)
+  - Dolphin Memory Engine, as part of the Prime AP Client, can not access regular Dolphin's process but can access Flatpak's containerized Dolphin's process
 
 ### In-Game Troubleshooting
 - In Dolphin, when fighting Ridley my screen keeps changing width

--- a/docs/setup_en.md
+++ b/docs/setup_en.md
@@ -22,21 +22,14 @@ The following are required in order to play _Metroid Prime_ in Archipelago:
 
 >[!NOTE]
 > Because Archipelago 5.1 on Windows transitioned to using Python 3.12, current releases of Metroid Prime AP offers two options to download:
-> | Archipelago Version                             |                                              |
-> |-------------------------------------------------|----------------------------------------------|
-> | Archipelago 5.1 or later for Windows            | Download APWorld file ending with `3.12.zip`.|
-> | Archipelago 5.1 AppImage or Tarball for Linux   | Download APWorld file ending with `3.11.zip`.|
-> | Archipelago 5.0 or earlier for Windows          | Download APWorld file ending with `3.11.zip`.|
+> | Archipelago Version                                       |                                              |
+> |-----------------------------------------------------------|----------------------------------------------|
+> | Archipelago 5.1 or later for Windows                      | Download APWorld file ending with `3.12.zip`.|
+> | Archipelago 5.0 or earlier for Windows                    | Download APWorld file ending with `3.11.zip`.|
+> | Archipelago 6.0 or later AppImage for Linux               | Download APWorld file ending with `3.12.zip`.|
+> | Archipelago 5.1 or earlier AppImage for Linux             | Download APWorld file ending with `3.11.zip`.|
 >
->  Future versions after Metroid Prime AP 0.4.9 will likely target only Python 3.12 and will only work on Archipelago 5.1.
-
->[!IMPORTANT]
-> If you have used a previous version of Metroid Prime AP that required copying folders into the `/lib` folder, go to your `Archipelago/lib` folder and delete the following directories:
-> - `dolphin_memory_engine` (This may be kept if another APWorld depends on this folder, but may cause issues if versions are mismatched.)
-> - `ppc_asm`
-> - `py_randomprime`
->
-> These are now included in the APWorld file.
+>  Future versions after Metroid Prime AP 0.4.9 will likely target only Python 3.12 and will only work on Archipelago 5.1 or newer.
 
 ## Setting Up Player Options YAML File
 
@@ -88,17 +81,12 @@ Once you do, follow these steps to connect to the room:
 - Use the latest Metroid Prime Archipelago release
   - Metroid Prime Archipelago: [Releases · Electro1512_MetroidAPrime](https://github.com/Electro1512/MetroidAPrime/releases)
 
-- Use the latest Dolphin Emulator
-  - Dolphin Emulator Release (**Recommended**): [Dolphin Emulator - Download](https://dolphin-emu.org/download/)
-  - PrimeHack: [Releases · shiiion/dolphin](https://github.com/shiiion/dolphin/releases)
-    - While the dependencies that Metroid Prime AP uses does not target PrimeHack, many users report that PrimeHack can work.
-      However, any issues found while using PrimeHack should be reproduced with the official Dolphin Emulator before reporting.
+- Use the latest Dolphin Emulator Release: [Dolphin Emulator - Download](https://dolphin-emu.org/download/)
 
 ### Generating and Patching Troubleshooting
 
 - If you do not see the client in the Archipelago Launcher
   - Ensure you have your `metroidprime.apworld` in the correct folder (The `custom_worlds` folder).
-  - Check if you have residual files from previous versions in the lib/worlds folder - see the [APWorld Installation section](#apworld-installation)
   - Go to `%TEMP%` (C:\Users\<Username>\AppData\Local\Temp) and delete the folder `ap_metroidprime_temp_lib_vX.Y.Z`. Then restart the Archipelago Launcher.
 
 - If you receive this error in a dialog box after opening the AP_XXXXX_PX.apmp1 file:


### PR DESCRIPTION
In the Readme  
- Removed Mods section (They're not officially supported)

In Setup Guide 
- Updated download info for Archipelago 6.0 Linux
- Removed steps to delete dolphin_memory_engine from the Archipelago/lib folder
- Removed mention of PrimeHack (It's not officially supported)
