### PR TITLE
Add client hints for scanning artifact totems

### DIFF
--- a/Config.py
+++ b/Config.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Dict, Any, List
 from .Items import ProgressiveUpgrade, SuitUpgrade
 
 
-from .PrimeOptions import HudColor, MetroidPrimeOptions
+from .PrimeOptions import ArtifactHints, HudColor, MetroidPrimeOptions
 from .data.RoomData import MetroidPrimeArea
 from .data.Transports import get_transport_data
 
@@ -73,7 +73,7 @@ def color_options_to_value(world: "MetroidPrimeWorld") -> List[float]:
 def make_artifact_hints(world: "MetroidPrimeWorld") -> Dict[str, str]:
     def make_artifact_hint(item: str) -> str:
         try:
-            if world.options.artifact_hints:
+            if world.options.artifact_hints.value != ArtifactHints.option_disable:
                 location = world.multiworld.find_item(item, world.player)
                 player_string = (
                     f"{world.multiworld.player_name[location.player]}'s"

--- a/Metroid Prime.yaml
+++ b/Metroid Prime.yaml
@@ -51,9 +51,10 @@ Metroid Prime:
     random-high: 0
 
   artifact_hints:
-    # If enabled, scanning the artifact stones in the temple will give a hint to their location. Additionally, hints will be pre collected in the client.
-    'false': 0
-    'true': 50
+    # If enabled, scanning the artifact stones in the temple will give a hint to their location. Additionally, hints may be pre-collected in the client.
+    'disable': 0
+    'enable_precollected': 50
+    'enable_scanned': 0
 
   final_bosses:
     # Determines the final bosses required to beat the seed. Choose from Meta Ridley, Metroid Prime,

--- a/MetroidPrimeClient.py
+++ b/MetroidPrimeClient.py
@@ -274,7 +274,6 @@ async def handle_artifact_hints(ctx: MetroidPrimeContext, scans: Dict[int, bool]
     if not artifact_locations:
         return
 
-    scans = ctx.game_interface.get_scans()
     scanned_hints: DefaultDict[int, List[int]] = DefaultDict(list)
     for artifact_name, asset_id in artifact_hint_scans.items():
         if scans.get(asset_id):

--- a/MetroidPrimeInterface.py
+++ b/MetroidPrimeInterface.py
@@ -376,6 +376,17 @@ class MetroidPrimeInterface:
                 inventory_item.current_capacity,
             )
 
+    def get_scans(self) -> Dict[int, bool]:
+        """Gets the state of each scan by its asset ID"""
+        vector_bytes = self.dolphin_client.read_pointer(
+            self.__get_player_state_pointer(), 0x170 + self.__get_vector_item_offset(), struct.calcsize(">iiI")
+        )
+        length, _capacity, item_pointer = struct.unpack(">iiI", vector_bytes)
+        item_bytes = self.dolphin_client.read_address(
+            item_pointer, length * struct.calcsize(">If")
+        )
+        return {asset_id: progress >= 1.0 for asset_id, progress in struct.iter_unpack(">If", item_bytes)}
+
     def connect_to_game(self):
         """Initializes the connection to dolphin and verifies it is connected to Metroid Prime"""
         try:

--- a/PrimeOptions.py
+++ b/PrimeOptions.py
@@ -61,10 +61,16 @@ class FinalBosses(Choice):
     default = 0
 
 
-class ArtifactHints(DefaultOnToggle):
-    """If enabled, scanning the artifact stones in the temple will give a hint to their location. Additionally, hints will be pre collected in the client."""
+class ArtifactHints(Choice):
+    """If enabled, scanning the artifact stones in the temple will give a hint to their location. Additionally, hints may be pre-collected in the client."""
 
     display_name = "Artifact Hints"
+    option_disable = 0
+    option_enable_precollected = 1
+    option_enable_scanned = 2
+    default = option_enable_precollected
+    alias_false = option_disable
+    alias_true = option_enable_precollected
 
 
 class MissileLauncher(Toggle):

--- a/__init__.py
+++ b/__init__.py
@@ -41,6 +41,7 @@ from .Regions import create_regions
 from .Locations import every_location
 from .ItemPool import generate_item_pool, generate_base_start_inventory
 from .PrimeOptions import (
+    ArtifactHints,
     BlastShieldRandomization,
     DoorColorRandomization,
     MetroidPrimeOptions,
@@ -305,7 +306,7 @@ class MetroidPrimeWorld(World):
         )
 
     def post_fill(self) -> None:
-        if self.options.artifact_hints:
+        if self.options.artifact_hints.value == ArtifactHints.option_enable_precollected:
             start_hints: typing.Set[str] = self.options.start_hints.value
             for i in artifact_table:
                 start_hints.add(i)
@@ -378,6 +379,9 @@ class MetroidPrimeWorld(World):
             slot_data["starting_room_name"] = self.starting_room_name
         if self.starting_beam:
             slot_data["starting_beam"] = self.starting_beam
+        if self.options.artifact_hints.value == ArtifactHints.option_enable_scanned:
+            locations = self.multiworld.find_items_in_locations(set(artifact_table.keys()), self.player)
+            slot_data["artifact_locations"] = { location.item.name: (location.address, location.player) for location in locations if location.item }
 
         return slot_data
 


### PR DESCRIPTION
Adds the option to make artifact hints in the AP client precollected or available once scanned [(if the server supports it)](https://github.com/ArchipelagoMW/Archipelago/pull/4317). The old true and false values for artifact_hints are aliased to maintain compatibility with old yamls.