### PR TITLE
Fix crash when using plando_items

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -358,6 +358,7 @@ class MetroidPrimeWorld(World):
             "artifact_hints",
             "staggered_suit_damage",
             "start_hints",
+            "plando_items",
         ]
         non_cosmetic_options = [
             o
@@ -467,3 +468,4 @@ class MetroidPrimeWorld(World):
                             f"    {room} <--> {destination}: {door_data.blast_shield.value}\n"
                         )
                         written_mappings.append([room, destination])
+


### PR DESCRIPTION
This fixes the Cannot handle <class 'Options.PlandoItem'> exception when using plando_items, allowing players to plando items.